### PR TITLE
Source flexibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -95,4 +95,5 @@ default['asterisk']['unimrcp']['rtp_port_max'] = '29000'
 
 #Install from source settings
 default['asterisk']['source']['packages'] = %w{build-essential libssl-dev libncurses5-dev libnewt-dev libxml2-dev libsqlite3-dev uuid-dev}
-default['asterisk']['source']['version'] = '11.5.1'
+default['asterisk']['source']['version']  = '11.5.1'
+default['asterisk']['source']['checksum'] = 'fefa9def9c8f97c89931f12b29b3ac616ae1a8454c01c524678163061dcb42b2'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -94,7 +94,7 @@ default['asterisk']['unimrcp']['rtp_port_min'] = '28000'
 default['asterisk']['unimrcp']['rtp_port_max'] = '29000'
 
 #Install from source settings
-default['asterisk']['source']['packages'] = %w{build-essential libssl-dev libncurses5-dev libnewt-dev libxml2-dev libsqlite3-dev uuid-dev}
+default['asterisk']['source']['packages'] = %w{build-essential libssl-dev libcurl4-openssl-dev libncurses5-dev libnewt-dev libxml2-dev libsqlite3-dev uuid-dev}
 default['asterisk']['source']['version']  = '11.5.1'
 default['asterisk']['source']['checksum'] = 'fefa9def9c8f97c89931f12b29b3ac616ae1a8454c01c524678163061dcb42b2'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -97,3 +97,6 @@ default['asterisk']['unimrcp']['rtp_port_max'] = '29000'
 default['asterisk']['source']['packages'] = %w{build-essential libssl-dev libncurses5-dev libnewt-dev libxml2-dev libsqlite3-dev uuid-dev}
 default['asterisk']['source']['version']  = '11.5.1'
 default['asterisk']['source']['checksum'] = 'fefa9def9c8f97c89931f12b29b3ac616ae1a8454c01c524678163061dcb42b2'
+
+# An full download url can be supplied to specify an alternative source tarball location
+default['asterisk']['source']['url']      = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,3 +100,6 @@ default['asterisk']['source']['checksum'] = 'fefa9def9c8f97c89931f12b29b3ac616ae
 
 # An full download url can be supplied to specify an alternative source tarball location
 default['asterisk']['source']['url']      = nil
+
+# Should the sample config files be installed?
+default['asterisk']['source']['install_samples'] = true

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -10,7 +10,7 @@ end
 # http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-11.3.0.tar.gz
 
 remote_file "/usr/local/src/asterisk-#{node['asterisk']['source']['version']}.tar.gz" do
-  source "http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-#{node['asterisk']['source']['version']}.tar.gz"
+  source "http://downloads.asterisk.org/pub/telephony/asterisk/releases/asterisk-#{node['asterisk']['source']['version']}.tar.gz"
 end
 
 bash "prepare_dir" do

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -15,7 +15,7 @@ source_path = "#{Chef::Config['file_cache_path'] || '/tmp'}/#{source_tarball}"
 remote_file source_tarball do
   source source_url
   path source_path
-  node['asterisk']['source']['checksum']
+  checksum node['asterisk']['source']['checksum']
   backup false
   notifies :create, 'ruby_block[validate asterisk tarball]', :immediately
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -44,7 +44,7 @@ bash "install_asterisk" do
     make
     make install
     make config
-    make samples
+    #{'make samples' if node['asterisk']['source']['install_samples']}
   EOH
   notifies :reload, resources(:service => "asterisk")
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -7,24 +7,23 @@ when "ubuntu","debian"
   end
 end
 
-# http://downloads.asterisk.org/pub/telephony/asterisk/asterisk-11.3.0.tar.gz
+source_tarball = "asterisk-#{node['asterisk']['source']['version']}.tar.gz"
+source_url =  "http://downloads.asterisk.org/pub/telephony/asterisk/releases/#{source_tarball}"
+source_path = "#{Chef::Config['file_cache_path'] || '/tmp'}/#{source_tarball}"
 
-remote_file "/usr/local/src/asterisk-#{node['asterisk']['source']['version']}.tar.gz" do
-  source "http://downloads.asterisk.org/pub/telephony/asterisk/releases/asterisk-#{node['asterisk']['source']['version']}.tar.gz"
-end
-
-bash "prepare_dir" do
-  user "root"
-  cwd "/usr/local/src"
-  code <<-EOH
-    tar -zxf asterisk-#{node['asterisk']['source']['version']}.tar.gz
-  EOH
+remote_file source_tarball do
+  source source_url
+  path source_path
+  checksum node['asterisk']['source']['checksum']
+  backup false
 end
 
 bash "install_asterisk" do
   user "root"
-  cwd "/usr/local/src/asterisk-#{node['asterisk']['source']['version']}"
+  cwd File.dirname(source_path)
   code <<-EOH
+    tar zxf #{source_path}
+    cd asterisk-#{node['asterisk']['source']['version']}
     ./configure
     make
     make install

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -8,7 +8,8 @@ when "ubuntu","debian"
 end
 
 source_tarball = "asterisk-#{node['asterisk']['source']['version']}.tar.gz"
-source_url =  "http://downloads.asterisk.org/pub/telephony/asterisk/releases/#{source_tarball}"
+source_url =  node['asterisk']['source']['url'] ||
+    "http://downloads.asterisk.org/pub/telephony/asterisk/releases/#{source_tarball}"
 source_path = "#{Chef::Config['file_cache_path'] || '/tmp'}/#{source_tarball}"
 
 remote_file source_tarball do


### PR DESCRIPTION
This is PR 2 of 3 in a series of cookbook enhancements we would like to push upstream.  Hopefully you will find the changes acceptable.  All of the changes in this set of PRs should maintain backwards compatibility.  We have additional patches we would like to contribute, but they depend on the changes made in the current set of PRs.

This PR adds a checksum attribute to verify source tarball integrity (sha256), an optional url attribute that can be set to specify an alternate download location, and an install_samples attribute that controls whether or not to install the asterisk sample config files.  Finally, it moves the build location to chef's cache directory.  This is to match the prevalent convention used by other source-building cookbooks in the community.
