### PR TITLE
Config flexibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,8 +87,8 @@ default['asterisk']['sip_conf_t38pt_udptl']          = 'yes'
 default['asterisk']['sip_providers'] = Mash.new
 default['asterisk']['sip_providers']['flowroute'] = Mash.new(:type => 'friend', :host => 'sip.flowroute.com', :dtmf_mode => 'rfc2833', :context => 'flowroute', :canreinvite => 'no', :allowed_codecs => ['ulaw', 'g729'], :insecure => 'port,invite', :qualify => 'yes')
 
-# uncomment the following to set an explicit public IP for SIP behind NAT. Default is the current host's ip address (or ec2 public IP if on ec2)
-# asterisk[:public_ip] = '1.2.3.4'
+# Sensible defaults for public ip
+default['asterisk']['public_ip'] = node['ec2'] ? node['ec2']['public_ipv4'] : node['ipaddress']
 
 # UniMRCP settings
 default['asterisk']['unimrcp']['version'] = '1.0.0'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,11 @@ default['asterisk']['configure']['modules']    = true
 default['asterisk']['configure']['mrcp']       = false
 default['asterisk']['configure']['sip']        = true
 
+# Users and dialplans.  Configrable as attributes or from data bags
+default['asterisk']['users']                   = nil
+default['asterisk']['auth']                    = nil
+default['asterisk']['dialplan_contexts']       = nil
+
 #Setup the Manager.conf file, refer to: http://www.voip-info.org/tiki-index.php?page=Asterisk%20config%20manager.conf
 #[general]
 default['asterisk']['manager_enabled']         = 'yes'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,15 @@
 default['asterisk']['use_digium_repo']  = false
 default['asterisk']['packages']         = ['asterisk', 'asterisk-dev']
 
+#Config files we should manage
+default['asterisk']['configure']['extensions'] = true
+default['asterisk']['configure']['gtalk']      = true
+default['asterisk']['configure']['jabber']     = true
+default['asterisk']['configure']['manager']    = true
+default['asterisk']['configure']['modules']    = true
+default['asterisk']['configure']['mrcp']       = false
+default['asterisk']['configure']['sip']        = true
+
 #Setup the Manager.conf file, refer to: http://www.voip-info.org/tiki-index.php?page=Asterisk%20config%20manager.conf
 #[general]
 default['asterisk']['manager_enabled']         = 'yes'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -8,8 +8,8 @@ node.default['asterisk']['dialplan_contexts'] = dialplan_contexts
 
 node['asterisk']['configure'].each do |config, managed|
   next unless managed == true
-  template "/etc/asterisk/#{component}.conf" do
-    source "#{component}.conf.erb"
+  template "/etc/asterisk/#{config}.conf" do
+    source "#{config}.conf.erb"
     mode 0644
     notifies :reload, resources(:service => 'asterisk')
   end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -2,12 +2,15 @@ users = search(:asterisk_users) || []
 auth = search(:auth, "id:google") || []
 dialplan_contexts = search(:asterisk_contexts) || []
 
+node.default['asterisk']['users'] = users
+node.default['asterisk']['auth']  = auth
+node.default['asterisk']['dialplan_contexts'] = dialplan_contexts
+
 node['asterisk']['configure'].each do |config, managed|
   next unless managed == true
   template "/etc/asterisk/#{component}.conf" do
     source "#{component}.conf.erb"
     mode 0644
-    variables :users => users, :auth => auth[0], :dialplan_contexts => dialplan_contexts
     notifies :reload, resources(:service => 'asterisk')
   end
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -1,4 +1,3 @@
-external_ip = node[:ec2] ? node[:ec2][:public_ipv4] : node[:ipaddress]
 users = search(:asterisk_users) || []
 auth = search(:auth, "id:google") || []
 dialplan_contexts = search(:asterisk_contexts) || []
@@ -8,7 +7,7 @@ node['asterisk']['configure'].each do |config, managed|
   template "/etc/asterisk/#{component}.conf" do
     source "#{component}.conf.erb"
     mode 0644
-    variables :external_ip => external_ip, :users => users, :auth => auth[0], :dialplan_contexts => dialplan_contexts
+    variables :users => users, :auth => auth[0], :dialplan_contexts => dialplan_contexts
     notifies :reload, resources(:service => 'asterisk')
   end
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -3,11 +3,13 @@ users = search(:asterisk_users) || []
 auth = search(:auth, "id:google") || []
 dialplan_contexts = search(:asterisk_contexts) || []
 
-%w{sip manager modules extensions gtalk jabber}.each do |template_file|
-  template "/etc/asterisk/#{template_file}.conf" do
-    source "#{template_file}.conf.erb"
+node['asterisk']['configure'].each do |config, managed|
+  next unless managed == true
+  template "/etc/asterisk/#{component}.conf" do
+    source "#{component}.conf.erb"
     mode 0644
     variables :external_ip => external_ip, :users => users, :auth => auth[0], :dialplan_contexts => dialplan_contexts
-    notifies :reload, resources(:service => "asterisk")
+    notifies :reload, resources(:service => 'asterisk')
   end
 end
+

--- a/recipes/unimrcp.rb
+++ b/recipes/unimrcp.rb
@@ -99,9 +99,3 @@ bash "ldconfig" do
     ldconfig
   EOH
 end
-
-template "/etc/asterisk/mrcp.conf" do
-  source "mrcp.conf.erb"
-  mode 0644
-  notifies :reload, resources(:service => "asterisk")
-end

--- a/recipes/unimrcp.rb
+++ b/recipes/unimrcp.rb
@@ -1,3 +1,5 @@
+node.default['asterisk']['configure']['mrcp'] = true
+
 case node['platform']
 when "ubuntu","debian"
   node['asterisk']['unimrcp']['packages'].each do |pkg|

--- a/templates/default/extensions.conf.erb
+++ b/templates/default/extensions.conf.erb
@@ -12,24 +12,24 @@ TRUNKMSD=1					; MSD digits to strip (usually 1 or 0)
 
 [default]
 exten => s,1,Set(CALLERID(name)=${DB(cidname/${CALLERID(num)})})
-<% if @users[0] %>
-exten => s,n,Dial(SIP/<%= @users[0]['username'] %>, 10)
+<% if node['asterisk']['users'][0] %>
+exten => s,n,Dial(SIP/<%= node['asterisk']['users'][0]['username'] %>, 10)
 <% end %>
 exten => s,n, Hangup
-<% if @users[0] %>
-exten => <%= @users[0]['username'] %>, 1, Dial(SIP/<%= @users[0]['username'] %>, 10)
+<% if node['asterisk']['users'][0] %>
+exten => <%= node['asterisk']['users'][0]['username'] %>, 1, Dial(SIP/<%= node['asterisk']['users'][0]['username'] %>, 10)
 <% end %>
 
 [google-in]
-<% if @auth %>
-exten => <%= @auth['username'] %>, 1, GotoIf(${DB_EXISTS(gv_dialout/channel)}?bridged)
-exten => <%= @auth['username'] %>, n, NoOp(Callerid  ${CALLERID(name)})
-exten => <%= @auth['username'] %>, n, Set(CALLERID(num)=${SHIFT(CALLERID(name),@)})
-exten => <%= @auth['username'] %>, n, Set(CALLERID(name)=${DB(cidname/${CALLERID(num)})})
-<% if @users[0] %>
-exten => <%= @auth['username'] %>, n, Dial(SIP/<%= @users[0]['username'] %>, 20, aD(:1))
+<% if node['asterisk']['auth'] %>
+exten => <%= node['asterisk']['auth']['username'] %>, 1, GotoIf(${DB_EXISTS(gv_dialout/channel)}?bridged)
+exten => <%= node['asterisk']['auth']['username'] %>, n, NoOp(Callerid  ${CALLERID(name)})
+exten => <%= node['asterisk']['auth']['username'] %>, n, Set(CALLERID(num)=${SHIFT(CALLERID(name),@)})
+exten => <%= node['asterisk']['auth']['username'] %>, n, Set(CALLERID(name)=${DB(cidname/${CALLERID(num)})})
+<% if node['asterisk']['users'][0] %>
+exten => <%= node['asterisk']['auth']['username'] %>, n, Dial(SIP/<%= node['asterisk']['users'][0]['username'] %>, 20, aD(:1))
 <% end %>
-exten => <%= @auth['username'] %>, n(bridged),Bridge(${DB_DELETE(gv_dialout/channel)}, p)
+exten => <%= node['asterisk']['auth']['username'] %>, n(bridged),Bridge(${DB_DELETE(gv_dialout/channel)}, p)
 <% end %>
 
 [outbound]
@@ -41,7 +41,7 @@ include => talk-numeric-outbound
 include => dial-uri
 
 [local-devices]
-<% @users.each do |user| %>
+<% node['asterisk']['users'].each do |user| %>
 exten => <%= user['extension'] %>, 1, Dial(SIP/<%= user['username'] %>, 10)
 <% end %>
 
@@ -71,7 +71,7 @@ exten => _[a-z].,1,Dial(SIP/${EXTEN}@${SIPDOMAIN},120,tr)
 exten => _[A-Z].,1,Dial(SIP/${EXTEN}@${SIPDOMAIN},120,tr)
 exten => _X.,1,Dial(SIP/${EXTEN}@${SIPDOMAIN},120,tr)
 
-<% @dialplan_contexts.each do |context| %>
+<% node['asterisk']['dialplan_contexts'].each do |context| %>
 [<%= context['name'] %>]
 <% context['entries'].each do |entry| %>
 <%= entry %>

--- a/templates/default/gtalk.conf.erb
+++ b/templates/default/gtalk.conf.erb
@@ -6,9 +6,9 @@ allowguest=yes
 disallow=all
 allow=ulaw
 
-<% if @auth %>
+<% if node['asterisk']['auth'] %>
 [gtalk]
-username=<%= @auth['username'] %>
+username=<%= node['asterisk']['auth']['username'] %>
 disallow=all
 allow=ulaw
 context=google-in

--- a/templates/default/jabber.conf.erb
+++ b/templates/default/jabber.conf.erb
@@ -1,12 +1,12 @@
 [general]
 autoregister=yes
 
-<% if @auth %>
+<% if node['asterisk']['auth'] %>
 [google]
 type=client
 serverhost=talk.google.com
-username=<%= @auth['username'] %>/Talk
-secret=<%= @auth['password'] %>
+username=<%= node['asterisk']['auth']['username'] %>/Talk
+secret=<%= node['asterisk']['auth']['password'] %>
 port=5222
 statusmessage=Asterisk Server - Not a Human
 status=xaway

--- a/templates/default/sip.conf.erb
+++ b/templates/default/sip.conf.erb
@@ -58,7 +58,7 @@ notifyhold = <%= node['asterisk']['sip_conf_notifyhold'] %>
 limitonpeers = <%= node['asterisk']['sip_conf_limitonpeers'] %>
 t38pt_udptl = <%= node['asterisk']['sip_conf_t38pt_udptl'] %>
 
-externip = <%= @external_ip %>	; Address that we're going to put in outbound SIP
+externip = <%= node['asterisk']['public_ip'] %>	; Address that we're going to put in outbound SIP
 
 
 

--- a/templates/default/sip.conf.erb
+++ b/templates/default/sip.conf.erb
@@ -102,7 +102,7 @@ externip = <%= node['asterisk']['public_ip'] %>	; Address that we're going to pu
 
 [authentication]
 
-<% @users.each do |user| %>
+<% node['asterisk']['users'].each do |user| %>
 [<%= user['username'] %>]
 defaultuser=<%= user['username'] %>
 secret=<%= user['password'] %>


### PR DESCRIPTION
This is PR 3 of 3 in a series of cookbook enhancements we would like to push upstream.  Hopefully you will find the changes acceptable.  All of the changes in this set of PRs should maintain backwards compatibility.  We have additional patches we would like to contribute, but they depend on the changes made in the current set of PRs.

This PR makes config files optional on a per-config basis.  The default attributes are set to match existing behavior.  Additionally, this PR allows the data bag configs to be set either by data bag or attributes.  Finally, it also fixes the public_ip attribute.
