### PR TITLE
User and path flexibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -101,6 +101,11 @@ default['asterisk']['unimrcp']['rtp_ip'] = '192.168.10.11'
 default['asterisk']['unimrcp']['rtp_port_min'] = '28000'
 default['asterisk']['unimrcp']['rtp_port_max'] = '29000'
 
+# Path config.  The default bin path is set according to the install method (source vs package)
+default['asterisk']['prefix']['bin']       = nil
+default['asterisk']['prefix']['conf']      = '/etc'
+default['asterisk']['prefix']['state']     = '/var'
+
 #Install from source settings
 default['asterisk']['source']['packages'] = %w{build-essential libssl-dev libcurl4-openssl-dev libncurses5-dev libnewt-dev libxml2-dev libsqlite3-dev uuid-dev}
 default['asterisk']['source']['version']  = '11.5.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,6 @@
+default['asterisk']['install_method']               = 'source'
+
+# Package install params
 default['asterisk']['package']['names']             = %w(asterisk asterisk-dev)
 default['asterisk']['package']['repo']['enable']    = false
 default['asterisk']['package']['repo']['url']       = 'http://packages.asterisk.org/deb'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,9 @@
 default['asterisk']['install_method']               = 'source'
 
+# Ownership / run-as user
+default['asterisk']['user']                = 'asterisk'
+default['asterisk']['group']               = 'asterisk'
+
 # Package install params
 default['asterisk']['package']['names']             = %w(asterisk asterisk-dev)
 default['asterisk']['package']['repo']['enable']    = false

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -3,6 +3,12 @@ users = search(:asterisk_users) || []
 auth = search(:auth, "id:google") || []
 dialplan_contexts = search(:asterisk_contexts) || []
 
+template "#{node['asterisk']['prefix']['conf']}/asterisk/asterisk.conf" do
+  source 'asterisk.conf.erb'
+  mode 0644
+  notifies :reload, resources(:service => 'asterisk')
+end
+
 %w{sip manager modules extensions}.each do |template_file|
   template "/etc/asterisk/#{template_file}.conf" do
     source "#{template_file}.conf.erb"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,3 +72,4 @@ end
 end
 
 include_recipe 'asterisk::config'
+include_recipe 'asterisk::init'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,26 +22,10 @@ asterisk_group = node['asterisk']['group']
 
 user node['asterisk']['user'] do
   system true
-  home "#{node['asterisk']['prefix']['state']}/lib/asterisk"
-  supports :manage_home => false    # Don't create the directory here
-  not_if do
-    begin
-      Etc.getpwnam asterisk_user
-    rescue
-      nil
-    end
-  end
 end
 
 group node['asterisk']['group'] do
   system true
-  not_if do
-    begin
-      Etc.getgrnam asterisk_group
-    rescue
-      nil
-    end
-  end
 end
 
 service "asterisk" do
@@ -63,11 +47,8 @@ end
     recursive true
   end
 
-  # The chown is used to fix initial permissions after asterisk is installed
-  # The conditional assumes permissions will remain correct afterwords
   execute "#{path} ownership" do
     command "chown -Rf #{asterisk_user}:#{asterisk_group} #{path}"
-    not_if { Etc.getpwuid(File.stat(path).uid).name == asterisk_user and Etc.getgrgid(File.stat(path).gid).name == asterisk_group }
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,3 +22,12 @@ service "asterisk" do
     "logger-reload" => true, "extensions-reload" => true,
     "restart-convenient" => true, "force-reload" => true
 end
+
+case node['asterisk']['install_method']
+  when 'package'
+    include_recipe 'asterisk::package'
+  when 'source'
+    include_recipe 'asterisk::source'
+end
+
+include_recipe 'asterisk::config'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,33 @@
 # limitations under the License.
 #
 
+asterisk_user = node['asterisk']['user']
+asterisk_group = node['asterisk']['group']
+
+user node['asterisk']['user'] do
+  system true
+  home "#{node['asterisk']['prefix']['state']}/lib/asterisk"
+  supports :manage_home => false    # Don't create the directory here
+  not_if do
+    begin
+      Etc.getpwnam asterisk_user
+    rescue
+      nil
+    end
+  end
+end
+
+group node['asterisk']['group'] do
+  system true
+  not_if do
+    begin
+      Etc.getgrnam asterisk_group
+    rescue
+      nil
+    end
+  end
+end
+
 service "asterisk" do
   supports :restart => true, :reload => true, :status => :true, :debug => :true,
     "logger-reload" => true, "extensions-reload" => true,
@@ -28,6 +55,20 @@ case node['asterisk']['install_method']
     include_recipe 'asterisk::package'
   when 'source'
     include_recipe 'asterisk::source'
+end
+
+%w(lib/asterisk spool/asterisk run/asterisk log/asterisk).each do |subdir|
+  path = "#{node['asterisk']['prefix']['state']}/#{subdir}"
+  directory path do
+    recursive true
+  end
+
+  # The chown is used to fix initial permissions after asterisk is installed
+  # The conditional assumes permissions will remain correct afterwords
+  execute "#{path} ownership" do
+    command "chown -Rf #{asterisk_user}:#{asterisk_group} #{path}"
+    not_if { Etc.getpwuid(File.stat(path).uid).name == asterisk_user and Etc.getgrgid(File.stat(path).gid).name == asterisk_group }
+  end
 end
 
 include_recipe 'asterisk::config'

--- a/recipes/init.rb
+++ b/recipes/init.rb
@@ -1,0 +1,11 @@
+template '/etc/default/asterisk' do
+  source 'init/default-asterisk.erb'
+  mode 0644
+  notifies :restart, resources(:service => 'asterisk')
+end
+
+template '/etc/init.d/asterisk' do
+  source 'init/init-asterisk.erb'
+  mode 0755
+  notifies :restart, resources(:service => 'asterisk')
+end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -1,3 +1,4 @@
+node.default['asterisk']['prefix']['bin']       = '/usr'
 
 case node['platform']
 when 'ubuntu', 'debian'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,3 +1,5 @@
+node.default['asterisk']['prefix']['bin']       = "/opt/asterisk-#{node['asterisk']['source']['version']}"
+
 case node['platform']
 when "ubuntu","debian"
   node['asterisk']['source']['packages'].each do |pkg|
@@ -40,7 +42,7 @@ bash "install_asterisk" do
   code <<-EOH
     tar zxf #{source_path}
     cd asterisk-#{node['asterisk']['source']['version']}
-    ./configure
+    ./configure --prefix=#{node['asterisk']['prefix']['bin']} --sysconfdir=#{node['asterisk']['prefix']['conf']} --localstatedir=#{node['asterisk']['prefix']['state']}
     make
     make install
     make config

--- a/templates/default/asterisk.conf.erb
+++ b/templates/default/asterisk.conf.erb
@@ -1,0 +1,15 @@
+; This file is managed by Chef for <%= node['fqdn'] %>
+; Do NOT modify this file directly.
+
+[directories]
+astetcdir => <%= node['asterisk']['prefix']['conf'] %>/asterisk
+astmoddir => <%= node['asterisk']['prefix']['bin'] %>/lib/asterisk/modules
+astagidir => <%= node['asterisk']['prefix']['bin'] %>/share/asterisk/agi-bin
+astvarlibdir => <%= node['asterisk']['prefix']['state'] %>/lib/asterisk
+astdatadir => <%= node['asterisk']['prefix']['state'] %>/lib/asterisk
+astspooldir => <%= node['asterisk']['prefix']['state'] %>/spool/asterisk
+astrundir => <%= node['asterisk']['prefix']['state'] %>/run/asterisk
+astlogdir => <%= node['asterisk']['prefix']['state'] %>/log/asterisk
+
+[options]
+languageprefix = yes ; Use the new sound prefix path syntax

--- a/templates/default/init/default-asterisk.erb
+++ b/templates/default/init/default-asterisk.erb
@@ -1,0 +1,48 @@
+# This file is managed by Chef for <%= node['fqdn'] %>
+# Do NOT modify this file directly.
+
+# Startup configuration for the Asterisk daemon
+
+# Uncomment the following and set them to the user/groups that you
+# want to run Asterisk as. NOTE: this requires substantial work to
+# be sure that Asterisk's environment has permission to write the
+# files required  for  its  operation, including logs, its comm
+# socket, the asterisk database, etc.
+AST_USER="<%= node['asterisk']['user'] %>"
+AST_GROUP="<%= node['asterisk']['group'] %>"
+
+# If you DON'T want Asterisk to start up with terminal colors, comment
+# this out.
+COLOR=yes
+
+# If you want Asterisk to run with a non-default configuration file,
+# uncomment the following option, and set the value appropriately.
+#ALTCONF=/etc/asterisk/asterisk.conf
+
+# In the case of a crash, Asterisk may create a core file.  Uncomment
+# if you want this behavior.
+#COREDUMP=yes
+
+# Asterisk may establish a maximum load average for the system.  This
+# may be useful to prevent a flood of calls from taking down the system.
+#MAXLOAD=4
+
+# Or, if you'd prefer, you can limit the maximum number of calls.
+#MAXCALLS=1000
+
+# Default console verbosity.  This may be raised or lowered on the console.
+# Note this is analogous to the -v command line switch, which by default
+# will cause Asterisk to start in console mode and run in the foreground,
+# unless the always fork (-F) option is also provided.
+#VERBOSITY=3
+
+# Enable internal timing if the DAHDI timer is available.  The default
+# behaviour is that outbound packets are phase locked to inbound packets.
+# Enabling this option causes them to be locked to the internal DAHDI
+# timer instead.
+#INTERNALTIMING=yes
+
+# Start all recordings into a temporary directory, before moving them to
+# their final location.
+#TEMPRECORDINGLOCATION=yes
+

--- a/templates/default/init/init-asterisk.erb
+++ b/templates/default/init/init-asterisk.erb
@@ -1,0 +1,148 @@
+#! /bin/sh
+#
+# This file is managed by Chef for <%= node['fqdn'] %>
+# Do NOT modify this file directly.
+#
+# Sun Aug 18 2013 Bob Ziuchkovski <bob@bz-technology.com>
+# - Templatize for use in chef asterisk cookbook
+#
+# Mon Jun 04 2007 Iñaki Baz Castillo <ibc@in.ilimit.es>
+# - Eliminated SAFE_ASTERISK since it doesn't work as LSB script (it could require a independent "safe_asterisk" init script).
+# - Load and use the standar "/lib/lsb/init-functions".
+# - Added "--oknodo" to "start-stop-daemon" for compatibility with LSB:
+#   http://www.linux-foundation.org/spec/refspecs/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
+#
+# Thu Nov 17 2005 Gregory Boehnlein <damin@nacs.net>
+# - Reversed behavior of LD_ASSUME_KERNEL=2.4.1
+# - Added detailed failure messages
+#
+# Sun Jul 18 2004 Gregory Boehnlein <damin@nacs.net>
+# - Added test for safe_asterisk
+# - Changed "stop gracefully" to "stop now"
+# - Added support for -U and -G command line options
+# - Modified "reload" to call asterisk -rx 'reload' 
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+NAME=asterisk
+DESC="Asterisk PBX"
+# Full path to asterisk binary
+DAEMON=<%= node['asterisk']['prefix']['bin'] %>/sbin/asterisk
+ASTVARRUNDIR=<%= node['asterisk']['prefix']['state'] %>/run/asterisk
+ASTETCDIR=<%= node['asterisk']['prefix']['conf'] %>/asterisk
+TRUE=/bin/true
+
+### BEGIN INIT INFO
+# Provides:		asterisk
+# Required-Start:    $network $syslog $named $local_fs $remote_fs
+# Required-Stop:     $network $syslog $named $local_fs $remote_fs
+# Should-Start:      dahdi misdn lcr wanrouter mysql postgresql
+# Should-Stop:       dahdi misdn lcr wanrouter mysql postgresql
+# Default-Start:	2 3 4 5
+# Default-Stop:		0 1 6
+# Short-Description:	Asterisk PBX
+# Description:		the Asterisk Open Source PBX
+### END INIT INFO
+
+set -e
+
+if ! [ -x $DAEMON ] ; then
+        echo "ERROR: $DAEMON not found"
+        exit 0
+fi
+
+if ! [ -d $ASTETCDIR ] ; then
+        echo "ERROR: $ASTETCDIR directory not found"
+        exit 0
+fi
+
+# Use the LSB standard functions for services management
+. /lib/lsb/init-functions
+
+# Allow configuration overrides in /etc/default/asterisk
+CONFIG0=`readlink $0 || :` # readlink returns 1 when something isn't a symlink
+if [ "$CONFIG0" = "" ]; then
+	CONFIGFILE=/etc/default/`basename $0`
+else
+	CONFIGFILE=/etc/default/`basename $CONFIG0`
+fi
+[ -r $CONFIGFILE ] && . $CONFIGFILE
+
+case "$1" in
+  start)
+	# Check if Asterisk is already running.  If it is, then bug out, because
+	# starting up Asterisk when Asterisk is already running is very bad.
+	VERSION=`${DAEMON} -rx 'core show version' 2>/dev/null || ${TRUE}`
+	if [ "`echo $VERSION | cut -c 1-8`" = "Asterisk" ]; then
+		echo "Asterisk is already running.  $0 will exit now."
+		exit 0
+	fi
+
+	log_begin_msg "Starting $DESC: $NAME"
+	if [ ! -d $ASTVARRUNDIR ]; then
+		mkdir -p $ASTVARRUNDIR
+	fi
+	if [ $AST_USER ] ; then
+		ASTARGS="-U $AST_USER"
+		chown $AST_USER $ASTVARRUNDIR
+	fi
+	if [ $AST_GROUP ] ; then
+		ASTARGS="$ASTARGS -G $AST_GROUP"
+		chgrp $AST_GROUP $ASTVARRUNDIR
+	fi
+	if [ $ALTCONF ]; then
+		ASTARGS="$ASTARGS -C \"$ALTCONF\""
+	fi
+	if [ "x$COREDUMP" = "xyes" ]; then
+		ASTARGS="$ASTARGS -g"
+	fi
+	if [ "0$MAXLOAD" -gt "0" ]; then
+		ASTARGS="$ASTARGS -L $MAXLOAD"
+	fi
+	if [ "0$MAXCALLS" -gt "0" ]; then
+		ASTARGS="$ASTARGS -M $MAXCALLS"
+	fi
+	if [ "0$VERBOSITY" -gt "0" ]; then
+		for i in `seq 1 $VERBOSITY`; do
+			ASTARGS="$ASTARGS -v"
+		done
+		# -v implies -f, so we override that implicit specification here
+		ASTARGS="$ASTARGS -F"
+	fi
+	if [ "x$INTERNALTIMING" = "xyes" ]; then
+		ASTARGS="$ASTARGS -I"
+	fi
+	if [ "x$TEMPRECORDINGLOCATION" = "xyes" -o "x$TMPRECORDINGLOCATION" = "xyes" ]; then
+		ASTARGS="$ASTARGS -t"
+	fi
+	if test "x$COLOR" = "xno" ; then
+		ASTARGS="$ASTARGS -n"
+	fi
+	# "start-stop-daemon --oknodo" returns 0 even if Asterisk was already running (as LSB expects):
+	start-stop-daemon --start --oknodo --exec $DAEMON -- $ASTARGS
+	log_end_msg $?
+	;;
+  stop)
+	log_begin_msg "Stopping $DESC: $NAME"
+	# "start-stop-daemon --oknodo" returns 0 even if Asterisk was already stopped (as LSB expects):
+	start-stop-daemon --stop --oknodo --exec $DAEMON
+	log_end_msg $?
+	;;
+  reload)
+	echo "Reloading $DESC configuration files."
+	$DAEMON -rx 'module reload' > /dev/null 2> /dev/null
+	;;
+  restart|force-reload)
+	$0 stop
+	sleep 2  # It needs some time to really be stopped.
+	$0 start
+	# "restart|force-reload" starts Asterisk and returns 0 even if Asterisk was stopped (as LSB expects).
+	;;
+  status)
+       status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+       ;;
+  *)
+	N=/etc/init.d/$NAME
+	echo "Usage: $N {start|stop|restart|reload|force-reload|status}" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
This is another in the series of PRs I have.  The primary goals of this PR are to support installation to a different bin prefix (/opt/asterisk-<version>) and to run asterisk as a non-root user and group for security purposes (asterisk/asterisk by default).

In order to do so, we have to put the init script under chef management, but that opens the potential to add runit/upstart/etc. support in the future.

Right now the init scripts are added as part of an 'init' recipe that's included at the end of the package and source recipes.  This is kind of ugly.  We have another changeset that inverts everything so that the 'default' recipe includes the config recipe, the package/source recipes according to an install_method attr, and the init config is added at the end.
