### PR TITLE
Invert recipe inclusion

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,6 @@
+default['asterisk']['install_method']               = 'source'
+
+# Package install params
 default['asterisk']['package']['names']             = %w(asterisk asterisk-dev)
 default['asterisk']['package']['repo']['enable']    = false
 default['asterisk']['package']['repo']['url']       = 'http://packages.asterisk.org/deb'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,3 +22,12 @@ service "asterisk" do
     "logger-reload" => true, "extensions-reload" => true,
     "restart-convenient" => true, "force-reload" => true
 end
+
+case node['asterisk']['install_method']
+  when 'package'
+    include_recipe 'asterisk::package'
+  when 'source'
+    include_recipe 'asterisk::source'
+end
+
+include_recipe 'asterisk::config'


### PR DESCRIPTION
Include all needed recipes from default.  Install method defaults to source install.
