### PR TITLE
Fix handling of the aterisk.prefix.conf attribute

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -1,14 +1,17 @@
 users = data_bag(:asterisk_users) || []
 dialplan_contexts = data_bag(:asterisk_contexts) || []
+config_dir = "#{node['asterisk']['prefix']['conf']}/asterisk"
 
-template "#{node['asterisk']['prefix']['conf']}/asterisk/asterisk.conf" do
+directory config_dir
+
+template "#{config_dir}/asterisk.conf" do
   source 'asterisk.conf.erb'
   mode 0644
   notifies :reload, resources('service[asterisk]')
 end
 
 %w{sip manager modules extensions}.each do |template_file|
-  template "/etc/asterisk/#{template_file}.conf" do
+  template "#{config_dir}/#{template_file}.conf" do
     source "#{template_file}.conf.erb"
     mode 0644
     variables :users => users, :dialplan_contexts => dialplan_contexts

--- a/recipes/unimrcp.rb
+++ b/recipes/unimrcp.rb
@@ -86,7 +86,7 @@ bash "ldconfig" do
   code 'ldconfig'
 end
 
-template "/etc/asterisk/mrcp.conf" do
+template "#{node['asterisk']['prefix']['conf']}/asterisk/mrcp.conf" do
   source "mrcp.conf.erb"
   mode 0644
   notifies :reload, resources('service[asterisk]')

--- a/templates/default/init/default-asterisk.erb
+++ b/templates/default/init/default-asterisk.erb
@@ -17,7 +17,7 @@ COLOR=yes
 
 # If you want Asterisk to run with a non-default configuration file,
 # uncomment the following option, and set the value appropriately.
-#ALTCONF=/etc/asterisk/asterisk.conf
+ALTCONF="<%= node['asterisk']['prefix']['conf'] %>/asterisk/asterisk.conf"
 
 # In the case of a crash, Asterisk may create a core file.  Uncomment
 # if you want this behavior.

--- a/templates/default/init/init-asterisk.erb
+++ b/templates/default/init/init-asterisk.erb
@@ -90,7 +90,7 @@ case "$1" in
 		chgrp $AST_GROUP $ASTVARRUNDIR
 	fi
 	if [ $ALTCONF ]; then
-		ASTARGS="$ASTARGS -C \"$ALTCONF\""
+		ASTARGS="$ASTARGS -C $ALTCONF"
 	fi
 	if [ "x$COREDUMP" = "xyes" ]; then
 		ASTARGS="$ASTARGS -g"


### PR DESCRIPTION
This PR ensures the asterisk.prefix.conf attr is used in place of hard-coded /etc in recipes, and that asterisk is started with the correct path to asterisk.conf.
