### PR TITLE
Allow arbitrary settings on SIP peers

### DIFF
--- a/data_bags/asterisk_users/usera.json
+++ b/data_bags/asterisk_users/usera.json
@@ -6,4 +6,9 @@
   "password": "usera",
   "username": "usera",
   "context": "adhearsion"
+  "additional_settings": {
+    "transport": "ws,wss",
+    "avpf": "yes",
+    "encryption": "yes"
+  }
 }

--- a/templates/default/sip.conf.erb
+++ b/templates/default/sip.conf.erb
@@ -109,4 +109,9 @@ type=friend
 callerid="<%= user['full_name'] %> <<%= user['username'] %>>"
 host=dynamic
 context=<%= user['context'] %>
+<% if user['additional_settings']
+     user['additional_settings'].each do |key, value| %>
+<%= "#{key}=#{value}" %>
+   <% end
+   end %>
 <% end %>


### PR DESCRIPTION
This PR allows user definitions to include arbitrary SIP settings.  I've included a sample of configs required for WebRTC to illustrate usage.  While we could try to keep up with exposing every last option from sip.conf, that seems like a losing battle with little to gain.
