### PR TITLE
Remove reading of contexts/users from databags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * Remove reading of contexts/users from databags. These should be replaced by included files per context/user and potentially a LWRP.
 
 # 1.1.1
   * Attribute typo in template

--- a/data_bags/asterisk_contexts/adhearsion.json
+++ b/data_bags/asterisk_contexts/adhearsion.json
@@ -1,7 +1,0 @@
-{
-  "id": "adhearsion",
-  "name": "adhearsion",
-  "entries": [
-    "exten => _.,1,AGI(agi:async)"
-  ]
-}

--- a/data_bags/asterisk_users/usera.json
+++ b/data_bags/asterisk_users/usera.json
@@ -1,9 +1,0 @@
-{
-  "id": "usera",
-  "data_bag": "asterisk_users",
-  "extension": 100,
-  "full_name": "User A",
-  "password": "usera",
-  "username": "usera",
-  "context": "adhearsion"
-}

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -1,9 +1,3 @@
-def data_bag_items(bag_name)
-  data_bag(bag_name).map { |id| data_bag_item bag_name, id }
-end
-
-users = data_bag_items(:asterisk_users)
-dialplan_contexts = data_bag_items(:asterisk_contexts)
 config_dir = "#{node['asterisk']['prefix']['conf']}/asterisk"
 
 if platform_family?('rhel', 'fedora')
@@ -27,7 +21,6 @@ end
   template "#{config_dir}/#{template_file}.conf" do
     source "#{template_file}.conf.erb"
     mode 0644
-    variables :users => users, :dialplan_contexts => dialplan_contexts
     notifies :reload, resources('service[asterisk]')
   end
 end

--- a/templates/default/extensions.conf.erb
+++ b/templates/default/extensions.conf.erb
@@ -11,24 +11,13 @@ TRUNKMSD=1					  ; MSD digits to strip (usually 1 or 0)
 
 [default]
 exten => s,1,Set(CALLERID(name)=${DB(cidname/${CALLERID(num)})})
-<% if @users[0] %>
-exten => s,n,Dial(SIP/<%= @users[0]['username'] %>, 10)
-<% end %>
 exten => s,n, Hangup
-<% if @users[0] %>
-exten => <%= @users[0]['username'] %>, 1, Dial(SIP/<%= @users[0]['username'] %>, 10)
-<% end %>
 
 [outbound]
 include => seven-digit
 include => local-devices
 include => tollfree
 include => dial-uri
-
-[local-devices]
-<% @users.each do |user| %>
-exten => <%= user['extension'] %>, 1, Dial(SIP/<%= user['username'] %>, 10)
-<% end %>
 
 [tollfree]
 exten => _411, 1, Dial(SIP/18004664411@proxy.ideasip.com,60)
@@ -47,10 +36,3 @@ exten => _NXXNXXXXXX,n,Goto(1${EXTEN},1)
 exten => _[a-z].,1,Dial(SIP/${EXTEN}@${SIPDOMAIN},120,tr)
 exten => _[A-Z].,1,Dial(SIP/${EXTEN}@${SIPDOMAIN},120,tr)
 exten => _X.,1,Dial(SIP/${EXTEN}@${SIPDOMAIN},120,tr)
-
-<% @dialplan_contexts.each do |context| %>
-[<%= context['name'] %>]
-<% context['entries'].each do |entry| %>
-<%= entry %>
-<% end %>
-<% end %>

--- a/templates/default/sip.conf.erb
+++ b/templates/default/sip.conf.erb
@@ -100,13 +100,3 @@ externip = <%= node['asterisk']['public_ip'] %>  ; Address that we're going to p
 
 
 [authentication]
-
-<% @users.each do |user| %>
-[<%= user['username'] %>]
-defaultuser=<%= user['username'] %>
-secret=<%= user['password'] %>
-type=friend
-callerid="<%= user['full_name'] %> <<%= user['username'] %>>"
-host=dynamic
-context=<%= user['context'] %>
-<% end %>

--- a/test/integration/package/serverspec/localhost/asterisk_spec.rb
+++ b/test/integration/package/serverspec/localhost/asterisk_spec.rb
@@ -16,31 +16,6 @@ describe 'asterisk' do
     it { should be_listening.with('udp') }
   end
 
-  describe file("/etc/asterisk/extensions.conf") do
-    it {
-      should contain(<<-CONTEXT
-[adhearsion]
-exten => _.,1,AGI(agi:async)
-      CONTEXT
-      )
-    }
-  end
-
-  describe file("/etc/asterisk/sip.conf") do
-    it {
-      should contain(<<-CONTEXT
-[usera]
-defaultuser=usera
-secret=usera
-type=friend
-callerid="User A <usera>"
-host=dynamic
-context=adhearsion
-      CONTEXT
-      )
-    }
-  end
-
   describe package('sox') do
     it { should be_installed }
   end

--- a/test/integration/source/serverspec/localhost/asterisk_spec.rb
+++ b/test/integration/source/serverspec/localhost/asterisk_spec.rb
@@ -16,31 +16,6 @@ describe 'asterisk' do
     it { should be_listening.with('udp') }
   end
 
-  describe file("/etc/asterisk/extensions.conf") do
-    it {
-      should contain(<<-CONTEXT
-[adhearsion]
-exten => _.,1,AGI(agi:async)
-      CONTEXT
-      )
-    }
-  end
-
-  describe file("/etc/asterisk/sip.conf") do
-    it {
-      should contain(<<-CONTEXT
-[usera]
-defaultuser=usera
-secret=usera
-type=friend
-callerid="User A <usera>"
-host=dynamic
-context=adhearsion
-      CONTEXT
-      )
-    }
-  end
-
   describe package('sox') do
     it { should be_installed }
   end


### PR DESCRIPTION
Databags should be managed only by application cookbooks since they are highly deployment-specific. These should be replaced by included files per context/user and potentially a LWRP.
